### PR TITLE
Changes to allow this compile on RHEL6/CentOS6

### DIFF
--- a/_gnu-make/Makefile
+++ b/_gnu-make/Makefile
@@ -30,10 +30,10 @@ buildir := $(realpath .)/build
 binsubdir := $(platform)-$(architecture)
 bindir := $(prefix)/bin/$(binsubdir)
 
-CFLAGS := -O2 -g -Wall -pedantic -Werror
+CFLAGS := -O2 -g -Wall -Werror
 
 ifeq ($(platform),linux)
-override LDFLAGS := $(LDFLAGS) -ldl
+override LDFLAGS := $(LDFLAGS) -ldl -lstdc++
 endif
 
 ifeq ($(platform),mac)


### PR DESCRIPTION
pedantic is really what is says on the tin. Won't compile because of this:

/whereami/src/whereami.c:1:1: error: C++ style comments are not allowed in ISO C90

-lstdc++ needed because of linker issue:

cc -x c++ -o /whereami/bin/linux-x86_64/executable-cpp -I /whereami/src  -O2 -g -Werror  -ldl -fpic /whereami/src/whereami.c /whereami/example/executable.c
/tmp/ccqatR1p.o:(.data.DW.ref.__gxx_personality_v0[DW.ref.__gxx_personality_v0]+0x0): undefined reference to `__gxx_personality_v0'
collect2: ld returned 1 exit status
