### PR TITLE
Unbreak on more BSDs

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -546,7 +546,8 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
-#elif defined(__FreeBSD__)
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 
 #include <limits.h>
 #include <stdlib.h>


### PR DESCRIPTION
DragonFly[*](https://github.com/DragonFlyBSD/DragonFlyBSD/commit/f849311b84a9d80fed3dcd8b0ed2a1c9bd46baf9) and NetBSD[*](https://github.com/jsonn/src/commit/b373ed6f85163c86d68ab2e20f8adee26e2daefd)[*](https://github.com/jsonn/src/commit/02f8b6ce550271aee18ecb9a147a103b5ea47e5b) recently implemented `KERN_PROC_PATHNAME` but ...

``` c
src/whereami.c:655:2: error: unsupported platform
#error unsupported platform
 ^
1 error generated.
```
