### PR TITLE
netbsd does not have KERN_PROC_PATHNAME but /proc/self/exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Supported platforms:
 - Android
 - QNX Neutrino
 - FreeBSD
+- NetBSD
+- DragonFly BSD
 - SunOS
 
 Just drop `whereami.h` and `whereami.c` into your build and get started. (see

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -158,7 +158,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
   return length;
 }
 
-#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun)
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -581,7 +581,11 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
 
   for (;;)
   {
+#if defined(__NetBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
     int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
     size_t size = sizeof(buffer1);
 
     if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0)


### PR DESCRIPTION
Hi, thanx for your library ! 
(I am using it for my own project yabasic)

Found it is not working out of the box on netbsd but a simple modification helps.

Tested for netbsd 8.0

Thanx for merging (if you do …) !
