### PR TITLE
Add __BSD_VISIBLE define

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -574,6 +574,7 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || \
       defined(__FreeBSD_kernel__) || defined(__NetBSD__)
 
+#define __BSD_VISIBLE 1
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Some projects including this as a simple file dependency might have e.g. _ANSI_SOURCE defined in the compiler args, which unsets __BSD_VISIBLE, which hides the u_int type on FreeBSD.