### PR TITLE
solaris fix

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -222,16 +222,61 @@ int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
   return ok ? length : -1;
 }
 
+#ifdef __sun
+#include <dlfcn.h>
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#else
+
 #if !defined(WAI_PROC_SELF_MAPS_RETRY)
 #define WAI_PROC_SELF_MAPS_RETRY 5
 #endif
 
 #if !defined(WAI_PROC_SELF_MAPS)
-#if defined(__sun)
-#define WAI_PROC_SELF_MAPS "/proc/self/map"
-#else
 #define WAI_PROC_SELF_MAPS "/proc/self/maps"
-#endif
 #endif
 
 #if defined(__ANDROID__) || defined(ANDROID)
@@ -357,6 +402,8 @@ int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
 
   return length;
 }
+
+#endif
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
This patch fixes the Solaris support (tested on Solaris 10 and 11).

While the existing getExecutablePath() code works fine on Solaris the getModulePath() does not work.
The code assumes that the /proc/self/map file on Solaris has the same syntax as the /proc/self/maps file on Linux.
This is not the case, actually the /proc/self/map is even a binary file, see: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
The dladdr() based code that is already used for other platforms in whereami however works fine on Solaris too.
I added another copy of it (there is already is more than one) - this maybe could be merged.