### PR TITLE
Include <stdbool.h> only if _MSC_VER >= 1900

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -68,7 +68,13 @@ extern "C" {
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#if (_MSC_VER >= 1900)
 #include <stdbool.h>
+#else
+#define bool int
+#define false 0
+#define true 1
+#endif
 
 static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
 {


### PR DESCRIPTION
According to [Microsoft C/C++ language conformance by Visual Studio version](https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170), Visual Studio supports `<stdbool.h>` since version 15 (`_MSC_VER >= 1900`).