### PR TITLE
win32: replace the check for _MSC_VER by a more generic __has_include check

### DIFF
--- a/src/whereami.c
+++ b/src/whereami.c
@@ -68,8 +68,10 @@ extern "C" {
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-#if (_MSC_VER >= 1900)
-#include <stdbool.h>
+#if defined __has_include
+#  if __has_include (<stdbool.h>)
+#    include <stdbool.h>
+#  endif
 #else
 #define bool int
 #define false 0

--- a/src/whereami.c
+++ b/src/whereami.c
@@ -68,10 +68,13 @@ extern "C" {
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-#if defined __has_include
-#  if __has_include (<stdbool.h>)
-#    include <stdbool.h>
-#  endif
+
+#if (_MSC_VER >= 1900)
+#include <stdbool.h>
+#elif defined(__has_include)
+#if __has_include(<stdbool.h>)
+#include <stdbool.h>
+#endif
 #else
 #define bool int
 #define false 0


### PR DESCRIPTION
The check has the same effect since support for stdbool.h and __has_include were
both introduced in the same MSVC version, but at least now it also works with MinGW
